### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A comprehensive MCP server that provides Claude with full access to Brevo's marketing automation platform using the official `@getbrevo/brevo` Node.js SDK. Features 8 organized tools covering all major Brevo functionalities.
 
+<a href="https://glama.ai/mcp/servers/@samihalawa/brevo-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@samihalawa/brevo-mcp/badge" alt="Brevo Server MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🔧 **Official Brevo SDK** - Built with `@getbrevo/brevo` for maximum compatibility


### PR DESCRIPTION
This PR adds a badge for the [Brevo MCP Server](https://glama.ai/mcp/servers/@samihalawa/brevo-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@samihalawa/brevo-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@samihalawa/brevo-mcp/badge" alt="Brevo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.